### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ It must contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
  * `list_locations` - Lists the available testing locations for your instance. Takes no arguments.

--- a/actions/list_locations.yaml
+++ b/actions/list_locations.yaml
@@ -1,6 +1,6 @@
 ---
 name: "list_locations"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "List available testing locations."
 enabled: true
 entry_point: "list_locations.py"

--- a/actions/random_test.yaml
+++ b/actions/random_test.yaml
@@ -1,6 +1,6 @@
 ---
 name: "random_test"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Test a domain on WebPageTest from a random location."
 enabled: true
 entry_point: "random_test.py"

--- a/actions/request_test.yaml
+++ b/actions/request_test.yaml
@@ -1,6 +1,6 @@
 ---
 name: "request_test"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Test a domain on WebPageTest."
 enabled: true
 entry_point: "request_test.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: st2 content pack containing webpagetest integrations
 keywords:
   - webpagetest
   - benchmarking
-version: 0.2.0
+version: 0.3.0
 author: Linuturk
 email: linuturk@onitato.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.